### PR TITLE
Rename RandomGenerator to InsecureRandomGenerator

### DIFF
--- a/src/crypto/rsa.d
+++ b/src/crypto/rsa.d
@@ -153,7 +153,7 @@ public:
     }
 
 private:
-    static RandomGenerator rnd;
+    static InsecureRandomGenerator rnd;
 
     static BigInt generateRandomBigInt(uint bitLength, int highBit = -1, int lowBit = -1)
     {

--- a/src/crypto/utils.d
+++ b/src/crypto/utils.d
@@ -84,7 +84,8 @@ struct BigIntHelper
     */
 }
 
-struct RandomGenerator
+/++ Fast but cryptographically insecure source of random numbers. +/
+struct InsecureRandomGenerator
 {
     private static Mt19937 generator;
 


### PR DESCRIPTION
Because this is a cryptography library, users might assume that something named `crypto.utils.RandomGenerator` is a [cryptographically secure PRNG](https://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator), but it is not. So the name should be changed to avoid confusion.