### PR TITLE
Fix bias towards low numbers in `next(min, max)` when `1 + max - min` is not a power of 2

### DIFF
--- a/src/crypto/utils.d
+++ b/src/crypto/utils.d
@@ -95,12 +95,6 @@ struct RandomGenerator
 
     T next(T = uint)(T min = T.min, T max = T.max) if (is(Unqual!T == uint) || is(Unqual!T == int) || is(Unqual!T == ubyte) || is(Unqual!T == byte))
     {
-        long r = generator.front;
-        generator.popFront();
-
-        long _min = min;
-        long _max = max;
-        
-        return cast(T)(r % (_max - _min + 1) + _min);
+        return uniform!("[]", T, T, typeof(generator))(min, max, generator);
     }
 }


### PR DESCRIPTION
The existing implementation just uses modulo, which is fine when `1L + max - min` evenly divides `1L + generator.max`, but otherwise causes the result to bias towards low numbers.