### PR TITLE
Change immutable arguments & mutable arguments to `const` where appropriate

### DIFF
--- a/src/crypto/aes.d
+++ b/src/crypto/aes.d
@@ -186,7 +186,7 @@ class AES(uint Nb, uint Nk, uint Nr) if ((Nb == 4 && Nk == 4 && Nr == 10) || (Nb
     private uint[Nb * (Nr + 1)] w;
     private uint[Nb * (Nr + 1)] dw;
 
-    public this(ubyte[] k)
+    public this(in ubyte[] k)
     {
         keyExpansion(k);
     }
@@ -307,7 +307,7 @@ class AES(uint Nb, uint Nk, uint Nr) if ((Nb == 4 && Nk == 4 && Nr == 10) || (Nb
         }
     }
 
-    private void keyExpansion(ubyte[] k)
+    private void keyExpansion(in ubyte[] k)
     {
         assert(k.length >= Nk * 4, "At least " ~ (Nk * 4).to!string ~ " bytes long key must be set");
 
@@ -347,19 +347,19 @@ class AES(uint Nb, uint Nk, uint Nr) if ((Nb == 4 && Nk == 4 && Nr == 10) || (Nb
 
 class AESUtils
 {
-    public static ubyte[] encrypt(alias T = AES128)(in ubyte[] buffer, string key)
+    public static ubyte[] encrypt(alias T = AES128)(in ubyte[] buffer, in char[] key)
     {
         return encrypt_decrypt!(T, "encrypt")(buffer, key);
     }
 
-    public static ubyte[] decrypt(alias T = AES128)(in ubyte[] buffer, string key)
+    public static ubyte[] decrypt(alias T = AES128)(in ubyte[] buffer, in char[] key)
     {
         return encrypt_decrypt!(T, "decrypt")(buffer, key);
     }
 
-    private static ubyte[] encrypt_decrypt(alias T1 = AES128, string T2)(in ubyte[] buffer, string key)
+    private static ubyte[] encrypt_decrypt(alias T1 = AES128, string T2)(in ubyte[] buffer, in char[] key)
     {
-        ubyte[] bkey = cast(ubyte[]) key;
+        const ubyte[] bkey = cast(const ubyte[]) key;
 
         T1 aes = new T1(bkey);
 

--- a/src/crypto/base58.d
+++ b/src/crypto/base58.d
@@ -22,7 +22,7 @@ public class Base58
     }
 
     /// Encodes the given bytes as a base58 string (no checksum is appended).
-    public static string encode(byte[] inp)
+    public static string encode(in byte[] inp)
     {
         if (inp.length == 0)
         {
@@ -64,7 +64,7 @@ public class Base58
     }
 
     /// Decodes the given base58 string into the original data bytes.
-    public static byte[] decode(string input)
+    public static byte[] decode(in char[] input)
     {
         if (input.length == 0)
         {

--- a/src/crypto/rsa.d
+++ b/src/crypto/rsa.d
@@ -304,7 +304,7 @@ private:
         int rounds = 64;
         size_t keySize = key.modulus_bytes.length;
 
-        void generateXteaKey(ubyte[] buf)
+        void generateXteaKey(in ubyte[] buf)
         {
             ubyte[] data = new ubyte[int.sizeof * 4];
             for (int i = 0; i < int.sizeof * 4; i++)

--- a/src/crypto/tea.d
+++ b/src/crypto/tea.d
@@ -76,7 +76,7 @@ package struct TEA
 
 class Tea
 {
-	public static ubyte[] encrypt(ubyte[] input, string key)
+	public static ubyte[] encrypt(in ubyte[] input, in char[] key)
 	{
 		ubyte[] buf = cast(ubyte[])key;
 		int[4] bkey = [buf[0], buf[1], buf[2], buf[3]];
@@ -84,7 +84,7 @@ class Tea
 		return encrypt(input, bkey);
 	}
 	
-    public static ubyte[] encrypt(ubyte[] input, int[4] key)
+    public static ubyte[] encrypt(in ubyte[] input, int[4] key)
     {
         ubyte[] data = input.dup;
         int orgi_len = cast(int)data.length;
@@ -104,7 +104,7 @@ class Tea
         return data;
     }
 
-	public static ubyte[] decrypt(ubyte[] input, string key)
+	public static ubyte[] decrypt(in ubyte[] input, in char[] key)
 	{
 		ubyte[] buf = cast(ubyte[])key;
 		int[4] bkey = [buf[0], buf[1], buf[2], buf[3]];
@@ -112,7 +112,7 @@ class Tea
 		return decrypt(input, bkey);
 	}
 
-    public static ubyte[] decrypt(ubyte[] input, int[4] key)
+    public static ubyte[] decrypt(in ubyte[] input, int[4] key)
     {
         auto data = input.dup;
         TEA tea = TEA(key);
@@ -212,7 +212,7 @@ package struct XTEA
 
 class Xtea
 {
-	public static ubyte[] encrypt(ubyte[] input, string key, int rounds = 64)
+	public static ubyte[] encrypt(in ubyte[] input, in char[] key, int rounds = 64)
 	{
 		ubyte[] buf = cast(ubyte[])key;
 		int[4] bkey = [buf[0], buf[1], buf[2], buf[3]];
@@ -220,7 +220,7 @@ class Xtea
 		return encrypt(input, bkey, rounds);
 	}
 	
-    public static ubyte[] encrypt(ubyte[] input, int[4] key, int rounds = 64)
+    public static ubyte[] encrypt(in ubyte[] input, int[4] key, int rounds = 64)
     {
         ubyte[] data = input.dup;
         int orgi_len = cast(int)data.length;
@@ -240,7 +240,7 @@ class Xtea
         return data;
     }
 
-	public static ubyte[] decrypt(ubyte[] input, string key, int rounds = 64)
+	public static ubyte[] decrypt(in ubyte[] input, in char[] key, int rounds = 64)
 	{
 		ubyte[] buf = cast(ubyte[])key;
 		int[4] bkey = [buf[0], buf[1], buf[2], buf[3]];
@@ -248,7 +248,7 @@ class Xtea
 		return decrypt(input, bkey, rounds);
 	}
 
-    public static ubyte[] decrypt(ubyte[] input, int[4] key, int rounds = 64)
+    public static ubyte[] decrypt(in ubyte[] input, int[4] key, int rounds = 64)
     {
         auto data = input.dup;
         XTEA xtea = XTEA(key, rounds);

--- a/src/crypto/utils.d
+++ b/src/crypto/utils.d
@@ -23,7 +23,7 @@ struct BigIntHelper
         return app.data;
     }
 
-    static BigInt bigIntFromUByteArray(ubyte[] buffer)
+    static BigInt bigIntFromUByteArray(in ubyte[] buffer)
     {
         BigInt ret = BigInt("0");
 


### PR DESCRIPTION
When `string` argument is not saved (retained), replace with `in char[]`. When `ubyte[]` argument is not modified, replace with `in ubyte[]`.