### PR TITLE
Clear private state of AES and TEA in destructors

### DIFF
--- a/src/crypto/aes.d
+++ b/src/crypto/aes.d
@@ -191,6 +191,13 @@ class AES(uint Nb, uint Nk, uint Nr) if ((Nb == 4 && Nk == 4 && Nr == 10) || (Nb
         keyExpansion(k);
     }
 
+    ~this()
+    {
+        import crypto.utils : explicitZero;
+        explicitZero(cast(ubyte[]) w);
+        explicitZero(cast(ubyte[]) dw);
+    }
+
     public ubyte[] encrypt(in ubyte[] buffer)
     {
         ubyte[] message = buffer.dup;
@@ -361,7 +368,7 @@ class AESUtils
     {
         const ubyte[] bkey = cast(const ubyte[]) key;
 
-        T1 aes = new T1(bkey);
+        scope aes = new T1(bkey);
 
         if (T2 == "encrypt")
         {

--- a/src/crypto/tea.d
+++ b/src/crypto/tea.d
@@ -15,6 +15,12 @@ package struct TEA
         m_rounds = 32;
     }
 
+    ~this()
+    {
+        import crypto.utils : explicitZero;
+        explicitZero(cast(ubyte[]) m_key);
+    }
+
     /// Encrypt given ubyte array (length to be crypted must be 8 ubyte aligned)
     public alias Crypt!(EncryptBlock) Encrypt;
     /// Decrypt given ubyte array (length to be crypted must be 8 ubyte aligned)

--- a/src/crypto/utils.d
+++ b/src/crypto/utils.d
@@ -100,3 +100,46 @@ struct InsecureRandomGenerator
         return uniform!("[]", T, T, typeof(generator))(min, max, generator);
     }
 }
+
+private @nogc nothrow pure @system
+{
+    version (linux)
+        extern(C) void explicit_bzero(void* ptr, size_t cnt);
+    version (FreeBSD)
+        extern(C) void explicit_bzero(void* ptr, size_t cnt);
+    version (OpenBSD)
+        extern(C) void explicit_bzero(void* ptr, size_t cnt);
+    version (OSX)
+        extern(C) int memset_s(void* ptr, size_t destsz, int c, size_t n);
+}
+
+/++
+Sets the array to all zero. On Linux, FreeBSD, and OpenBSD, uses
+`explicit_bzero` to prevent an optimizing compiler from deeming the
+data write "unnecessary" and omitting it. On Mac OS X uses `memset_s`
+for the same purpose. The typical use of this function is to erase
+secret keys after they are no longer needed.
+
+Limitations:
+On operating systems other than mentioned above this function is the
+same as `array[] = 0` and is not protected from being removed by the
+compiler.
++/
+void explicitZero(scope ubyte[] array) @nogc nothrow pure @trusted
+{
+    if (__ctfe)
+    {
+        array[] = 0;
+        return;
+    }
+    version (linux)
+        explicit_bzero(array.ptr, array.length);
+    else version (FreeBSD)
+        explicit_bzero(array.ptr, array.length);
+    else version (OpenBSD)
+        explicit_bzero(array.ptr, array.length);
+    else version (OSX)
+        memset_s(array.ptr, array.length, 0, array.length);
+    else
+        array[] = 0;
+}


### PR DESCRIPTION
Behavior is only guaranteed to be ideal on Linux/FreeBSD/OpenBSD/Mac OS X. Microsoft Windows `SecureZeroMemory` isn't available.