### PR TITLE
Use secure source of entropy to generate RSA keys

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,5 +4,8 @@
 	"description": "A D Library of encrypto, decrypto(3DES, AES, TEA, RSA...), encode, hash, and message digital signatures.",
 	"license": "Apache License, Version 2.0",
 	"copyright": "Copyright © 2018, Shove",
+	"dependencies": {
+		"mir-random": ">=0.3.6"
+	},
 	"targetName": "crypto"
 }

--- a/src/crypto/rsa.d
+++ b/src/crypto/rsa.d
@@ -159,14 +159,14 @@ private:
     {
         ubyte[] buffer = new ubyte[bitLength / 8];
 
-        uint pos = 0;
-        uint current = 0;
-        foreach (ref a; buffer)
+        for (ubyte[] unwritten = buffer; unwritten.length != 0;)
         {
-            if (pos == 0)
-                current = rnd.next;
-            a = cast(ubyte)(current >> 8 * pos);
-            pos = (pos + 1) % uint.sizeof;
+            import mir.random.engine : genRandomNonBlocking;
+            const n = genRandomNonBlocking(unwritten);
+            if (ptrdiff_t(0) <= cast(ptrdiff_t) n)
+                unwritten = unwritten[n .. $];
+            else
+                throw new Exception("Error trying to obtain system entropy to generate RSA key.");
         }
 
         if (highBit == 0)


### PR DESCRIPTION
Use a secure source of system entropy to generate random BigInts.
InsecureRandomGenerator is still used for the Miller-Rabin prime test.

_Implementation details of `genRandomNonBlocking`:_
On Windows it uses CryptGenRandom. On Linux it uses the GETRANDOM syscall if available, falling back to /dev/urandom otherwise. On Mac OS X and Android and OpenBSD and NetBSD it uses their modernized arc4random_buf. On other POSIX systems it just reads from /dev/urandom.