### PR TITLE
Fix buffer overrun in secureZeroMemory when using D_InlineAsm_X86_64 or D_InlineAsm_X86

### DIFF
--- a/src/crypto/utils.d
+++ b/src/crypto/utils.d
@@ -43,7 +43,7 @@ void secureZeroMemory(void* p, in size_t length) pure nothrow @nogc
             mov RCX, length;
             iter:
             xor RBX, RBX;
-            mov [RDX], RBX;
+            mov [RDX], BL;
             inc RDX;
             loop iter;
         }
@@ -57,7 +57,7 @@ void secureZeroMemory(void* p, in size_t length) pure nothrow @nogc
             mov ECX, length;
             iter:
             xor EBX, EBX;
-            mov [EDX], EBX;
+            mov [EDX], BL;
             inc EDX;
             loop iter;
         }
@@ -123,4 +123,19 @@ unittest
     i2 = [8, 5, 99, 5, 99];
     secureZeroMemory(cast(void[])i2);
     assert(i == i2);
+}
+
+unittest
+{
+    // Verify that secureZeroMemory doesn't have a buffer overrun.
+    ubyte[17] array;
+    array[] = 1;
+    ubyte[] slice = array[1..$-1];
+    secureZeroMemory(slice);
+    // Slice should be 0.
+    foreach (b; slice)
+        assert(b == 0);
+    // Bytes outside slice should be 1.
+    assert(array[0] == 1);
+    assert(array[$-1] == 1);
 }


### PR DESCRIPTION
In the loop the asm was writing an entire word (4 or 8 bytes) to the pointer instead of a single byte.